### PR TITLE
feat: Add COMPANY-STANDARD.md with interface location guidelines

### DIFF
--- a/COMPANY-STANDARD.md
+++ b/COMPANY-STANDARD.md
@@ -1,0 +1,11 @@
+# Company Standards
+
+## Interface/Type and Props locations
+
+- should not be in components 
+- should not be in hooks
+- should be located at in `./src/interfaces`
+- file name should be [component-name].interface.ts
+
+### example
+- if the component name is custom.tsx, then the file should be `./src/interfaces/custom.interface.ts`


### PR DESCRIPTION
Fixes #5

Adds the missing COMPANY-STANDARD.md file with company standards for interface/type locations:

- Interfaces/types should be in ./src/interfaces directory
- Naming convention: [component-name].interface.ts
- Should not be in components or hooks directories

Generated with [Claude Code](https://claude.ai/code)